### PR TITLE
updating algorithm to be O(Nlogn)

### DIFF
--- a/interval-scheduling/main.py
+++ b/interval-scheduling/main.py
@@ -133,8 +133,8 @@ def interval_schedule(activities):
 
     print('Total steps taken: %s' %step)
 
-    # Sort by start time again
-    return sorted(chosen, key=lambda act: act.start)
+    # Return... the chosen ones!
+    return chosen
 
 
 # Decorators and helpers for printing

--- a/interval-scheduling/main.py
+++ b/interval-scheduling/main.py
@@ -105,12 +105,12 @@ def interval_schedule(activities):
     chosen = []
     step = 0
 
+    # Sort activities so by soonest ending
+    activities = sorted(activities, key=lambda act: act.end)    
+
     while len(activities) > 0:
 
         step+=1
-
-        # Sort activities so by soonest ending
-        activities = sorted(activities, key=lambda act: act.end)    
         
         # Choose the earliest end time, tell the user
         activity = activities.pop(0)
@@ -119,8 +119,17 @@ def interval_schedule(activities):
         # Add activity to start always, since earlier are added later
         chosen.append(activity)
         
-        # Remove other activities with start times earlier than the start
-        activities = [a for a in activities if a.start >= activity.end]
+        # Keep track of some removed metrics for the user
+        keep_removing = True
+
+        # Remove (pop) other activities with start times earlier than the start
+        while keep_removing and len(activities) > 0:
+            next = activities[0]
+            if next.start < activity.end:
+                _ = activities.pop()
+            else:
+                keep_removing = False
+
 
     print('Total steps taken: %s' %step)
 

--- a/interval-scheduling/main.py
+++ b/interval-scheduling/main.py
@@ -126,7 +126,7 @@ def interval_schedule(activities):
         while keep_removing and len(activities) > 0:
             next = activities[0]
             if next.start < activity.end:
-                _ = activities.pop()
+                _ = activities.pop(0)
             else:
                 keep_removing = False
 


### PR DESCRIPTION
This pull request will address #2 by changing the complexity from O(n^2) to O(nlogN) by doing the following:

1. The ordering of the events only needs to happen once, *outside* of the while loop. Specifically, this line:

```python
# Sort activities so by soonest ending
activities = sorted(activities, key=lambda act: act.end)    
```
Then inside the loop, instead of iterating through the entire thing, we just move forward until we hit the first event that breaks the condition (and then stop).

```python
# Remove (pop) other activities with start times earlier than the start
while keep_removing and len(activities) > 0:
    next = activities[0]
    if next.start < activity.end:
        _ = activities.pop(0)
    else:
        keep_removing = False
```
Thus, when we find an activity that is in the sorted list that has a start time that is equal or greater (later than) the current, we *don't* pop it, and we set keep_removing to False to break from the loop. @tabakg would you care to review if the above changes deem the algorithm O(Nlogn)?